### PR TITLE
Update reference to latest path in bower dir

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = {
     delete this.options.enabled;
 
     if (this.enabled) {
-      app.import(app.bowerDirectory + '/flexibility/dist/flexibility.js');
+      app.import(app.bowerDirectory + '/flexibility/flexibility.js');
     }
   },
 


### PR DESCRIPTION
The latest version of flexibility doesn't have the `flexibility.js` inside the `dist` folder. This commit takes care of the reference update. Might want to bump major version so that existing users don't get affected by this change.